### PR TITLE
Adding check for valid threshold numbers.

### DIFF
--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -154,10 +154,8 @@ class WEDriver:
                 self.largest_allowed_weight = float(self.largest_allowed_weight)
                 self.smallest_allowed_weight = float(self.smallest_allowed_weight)
             except ValueError:
-                # Generate error saying thresholds are invalid.
-                assert isinstance(self.largest_allowed_weight, float) and isinstance(
-                    self.smallest_allowed_weight, float
-                ), "Invalid weight thresholds specified in west.cfg. Please check"
+                # Generate error saying thresholds are invalid
+                raise ValueError("Invalid weight thresholds specified. Please check your west.cfg.")
 
     @property
     def next_iter_segments(self):

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -587,16 +587,16 @@ class WEDriver:
                 # Check to see which walkers, when split, will result in
                 # a weight greater than the smallest allowed weight.
                 to_split = segments[weights / 2 >= float(self.smallest_allowed_weight)]
-                print(len(segments), weights[:], len(to_split))
+                log.debug(len(segments), weights[:], len(to_split))
                 if len(to_split) < 1:
-                    print("cannot split")
+                    log.debug('cannot split')
                     split_break = True
                 else:
                     # then split the highest probability walker into two
                     bin.remove(segments[-1])
                     i.remove(segments[-1])
                     new_segments_list = self._split_walker(to_split[-1], 2, bin)
-                    print("splitting occured")
+                    log.debug('splitting occured')
                     # KFW CHECK BACK                for new_segment in new_segments_list:
                     # KFW CHECK BACK                    try:
                     # KFW CHECK BACK                        new_segment.id_hist = list(segments[-1].id_hist)
@@ -625,14 +625,14 @@ class WEDriver:
                     weights = np.array(list(map(weight_getter, segments)))
                     # Check to see if the two lowest-probability walkers have
                     # a combined weight less than the largest allowed weight.
-                    print(len(segments), weights[:])
+                    log.debug(len(segments), weights[:])
                     if sum(weights[:2]) <= float(self.largest_allowed_weight):
                         to_merge = segments[:2]
                         # then merge the two lowest-probability walkers
                         bin.difference_update(segments[:2])
                         i.difference_update(segments[:2])
                         merged_segment, parent = self._merge_walkers(to_merge, cumul_weight=None, bin=bin)
-                        print("merging occured")
+                        log.debug('merging occured')
                         # KFW CHECK BACK                    try:
                         # KFW CHECK BACK                        merged_segment.id_hist = list(parent.id_hist)
                         # KFW CHECK BACK                    except AttributeError:
@@ -644,7 +644,7 @@ class WEDriver:
                         # in bash, "find . -name \*.py | xargs fgrep -n '_merge_walkers'"
                     else:
                         merge_break = True
-                        print("cannot merge")
+                        log.debug('cannot merge')
 
                     if len(bin) == target_count or merge_break is True:
                         break

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -591,7 +591,6 @@ class WEDriver:
                 if len(to_split) < 1:
                     print("cannot split")
                     split_break = True
-                    break
                 else:
                     # then split the highest probability walker into two
                     bin.remove(segments[-1])
@@ -606,11 +605,10 @@ class WEDriver:
                     i.update(new_segments_list)
                     bin.update(new_segments_list)
 
-                    if len(bin) == target_count:
-                        break
+                if len(bin) == target_count or split_break is True:
+                    break
 
             if split_break is True:
-                split_break = False
                 break
 
         # merge
@@ -644,16 +642,15 @@ class WEDriver:
                         # As long as we're changing the merge_walkers and split_walkers, adjust them so that they don't update the bin within the function
                         # and instead update the bin here.  Assuming nothing else relies on those.  Make sure with grin.
                         # in bash, "find . -name \*.py | xargs fgrep -n '_merge_walkers'"
-                        if len(bin) == target_count:
-                            break
                     else:
-                        print("cannot merge")
                         merge_break = True
+                        print("cannot merge")
+
+                    if len(bin) == target_count or merge_break is True:
                         break
 
-            if merge_break is True:
-                merge_break = False
-                break
+                if merge_break is True:
+                    break
 
     def _check_pre(self):
         for ibin, _bin in enumerate(self.next_iter_binning):

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -145,6 +145,20 @@ class WEDriver:
         self.smallest_allowed_weight = config.get(['west', 'we', 'smallest_allowed_weight'], self.smallest_allowed_weight)
         log.info('Smallest allowed_weight: {}'.format(self.smallest_allowed_weight))
 
+        # Checking to see if weight thresholds are valid
+        if (not np.issubdtype(type(self.largest_allowed_weight), np.floating)) or (
+            not np.issubdtype(type(self.smallest_allowed_weight), np.floating)
+        ):
+            try:
+                # Trying to self correct
+                self.largest_allowed_weight = float(self.largest_allowed_weight)
+                self.smallest_allowed_weight = float(self.smallest_allowed_weight)
+            except ValueError:
+                # Generate error saying thresholds are invalid.
+                assert isinstance(self.largest_allowed_weight, float) and isinstance(
+                    self.smallest_allowed_weight, float
+                ), "Invalid weight thresholds specified in west.cfg. Please check"
+
     @property
     def next_iter_segments(self):
         '''Newly-created segments for the next iteration'''

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -591,8 +591,9 @@ class WEDriver:
                 if len(to_split) < 1:
                     print("cannot split")
                     split_break = True
-                # then split the highest probability walker into two
+                    break
                 else:
+                    # then split the highest probability walker into two
                     bin.remove(segments[-1])
                     i.remove(segments[-1])
                     new_segments_list = self._split_walker(to_split[-1], 2, bin)
@@ -648,6 +649,7 @@ class WEDriver:
                     else:
                         print("cannot merge")
                         merge_break = True
+                        break
 
             if merge_break is True:
                 merge_break = False

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -80,7 +80,7 @@ class WEDriver:
     weight_split_threshold = 2.0
     weight_merge_cutoff = 1.0
     largest_allowed_weight = 1.0
-    smallest_allowed_weight = 0
+    smallest_allowed_weight = 1e-323
 
     def __init__(self, rc=None, system=None):
         self.rc = rc or westpa.rc


### PR DESCRIPTION
**Still checking the main functionality.**

Change log:
- Threshold input check (in `process_config()`)
Checks added to make sure the threshold numbers read from west.cfg are valid. If not, it attempts to self correct before throwing a `ValueError` error message. 

- Modified Algorithm to work with grouping function
Modified so segments weight thresholds are checked per group instead of per bin. The original code won't work as-is because the "segments" internal argument is used differently in the original code (2.0-thresholds) and in the binless scheme. It previously works if groups = bins (no custom group.py is specified) but would fail otherwise once splitting/merging with custom grouping function occurs.

- The default smallest_allowed_weight has been increased to 1e-323.
I suggest increasing the default min threshold to 1e-322 (or so) since that's what the 64-bit limit is. The simulation will crash regardless anyway (at ~1e-323), so why not do that? 
Internet research suggest that the 64-bit limit is at 2.22e-308 with reduced resolution under that. From experience, I observe problems at ~1e-323, but kT (probability dynamic range) would be at inf much higher, at around e-308

Current Issues/To Fix:
- The current algorithm checks if weights are larger when divided by 2. However, there are cases observed where segments are split into 3+ offspring segments which are less than the threshold. A similar case could occur for merging as well. Could be a problem if the threshold is too stringent (among other things).