### PR TITLE
Mab fit transform

### DIFF
--- a/src/westpa/core/binning/assign.py
+++ b/src/westpa/core/binning/assign.py
@@ -223,7 +223,8 @@ class FuncBinMapper(BinMapper):
         self.kwargs = kwargs or {}
         self.labels = ['{!r} bin {:d}'.format(func, ibin) for ibin in range(nbins)]
 
-    def assign(self, coords, mask=None, output=None):
+    def assign(self, coords, mask=None, output=None, **kwargs):
+
         try:
             passed_coord_dtype = coords.dtype
         except AttributeError:
@@ -244,7 +245,8 @@ class FuncBinMapper(BinMapper):
         elif len(output) != len(coords):
             raise TypeError('output has different length than coords')
 
-        self.func(coords, mask, output, *self.args, **self.kwargs)
+        kwargs.update(self.kwargs)
+        self.func(coords, mask, output, *self.args, **kwargs)
 
         return output
 

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -3,7 +3,7 @@ from westpa.core.binning import FuncBinMapper
 from westpa.core.binning.assign import index_dtype
 
 
-def map_mab(coords, mask, output, *args, assign_coords=None, **kwargs):
+def map_mab(coords, mask, output, *args, model_coords=None, **kwargs):
     """
     Binning which adaptively places bins based on the positions of extrema segments and
     bottleneck segments, which are where the difference in probability is the greatest
@@ -23,8 +23,9 @@ def map_mab(coords, mask, output, *args, assign_coords=None, **kwargs):
     output: array-like
         Array to populate with the mapped WE bins.
 
-    assign_coords: array-like, optional (default: None)
-        An optional set of coordinates to assign, based on MAB parameters calculated from :code:`coords`.
+    model_coords: array-like, optional (default: None)
+        An optional set of coordinates to use to calculate MAB parameters. If used, :code:`coords` will be binned based
+        on MAB parameters calculated from :code:`assign_coords`.
 
     nbins_per_dim: array-like
         Array storing the number of WE bins to place in each dimension.
@@ -38,24 +39,34 @@ def map_mab(coords, mask, output, *args, assign_coords=None, **kwargs):
     Returns
     -------
     array-like: The WE bin assignments for each segment.
+
+    Notes
+    -----
+    If using :code:`model_coords` to parameterize the MAB based on a different set of coordinates than what you're
+    assigning, be aware that if the coordinates in model_coords span a narrower space than the coordinates to assign,
+    some walkers will end up outside the boundary and an error will be thrown.
     """
 
     # If you provided a different set of coordinates to assign, then build a new mask based on that.
-    if assign_coords is not None:
-        assign_mask = np.ones((len(assign_coords),), dtype=np.bool_)
-        assign_output = np.empty((len(assign_coords),), dtype=index_dtype)
+    if model_coords is not None:
+        assign_mask = np.ones((len(model_coords),), dtype=np.bool_)
+        assign_output = np.empty((len(model_coords),), dtype=index_dtype)
 
     # If assign_coords is not provided, then this should default to the original behavior and just assign the segments
     #   that were initially provided
     else:
-        assign_coords = coords
-        assign_mask = mask
-        assign_output = output
+        model_coords = np.copy(coords)
+        assign_mask = np.copy(mask)
+        assign_output = np.copy(output)
 
-    mab_parameters = generate_mab_bins(coords, mask, output, *args, **kwargs)
+    mab_parameters = generate_mab_bins(model_coords, assign_mask, assign_output, *args, **kwargs)
 
     # coords, mask, output may be a different size here
-    assignments = assign_to_mab_bins(assign_coords, mab_parameters, assign_mask, assign_output, *args, **kwargs)
+    assignments = assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs)
+
+    # Pass the result out
+    for i, element in enumerate(output):
+        output[i] = element
 
     return assignments
 
@@ -80,6 +91,7 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     #   to generate the MAB parameters, and then apply that to another set of data.
 
     allcoords = np.copy(coords)
+    allmask = np.copy(mask)
 
     ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist = mab_parameters
 
@@ -93,7 +105,7 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     for i in range(len(output)):
 
         # If this segment isn't to be assigned, move on
-        if not mask[i]:
+        if not allmask[i]:
             continue
 
         special = False
@@ -151,6 +163,9 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
                     elif bin_number < 0:
                         bin_number = 0
 
+                # TODO: This is tripped if you parameterize from an iteration with a narrower range, and then try
+                #   to apply that to an iteration with a wider range of coordinates.
+                #   Would it be acceptable to expand the above 'if' to include this, and not make this an exception?
                 elif bin_number >= nbins or bin_number < 0:
                     raise ValueError("Walker out of boundary")
 
@@ -171,38 +186,41 @@ def get_final(coords, mask, ndim):
     allcoords = np.copy(coords)
     allmask = np.copy(mask)
 
-    if coords.shape[1] > ndim:
+    assert coords.shape[1] > ndim, (
+        f"Provided coordinates not the right shape. Was {coords.shape}, but should have "
+        f"dimension1 > {ndim}. Maybe you forgot to zip the weights and the final boolean?"
+    )
 
-        # If there's an extra dimension, then we've gotten the segment weights from the MAB driver.
-        if coords.shape[1] > ndim + 1:
+    # If there's an extra dimension, then we've gotten the segment weights from the MAB driver.
+    if coords.shape[1] > ndim + 1:
 
-            # This last index is 1 if it's a final segment, or 0 otherwise, so cast that to a boolean.
-            isfinal = allcoords[:, ndim + 1].astype(np.bool_)
+        # This last index is 1 if it's a final segment, or 0 otherwise, so cast that to a boolean.
+        isfinal = allcoords[:, ndim + 1].astype(np.bool_)
 
-        # This else is equivalent to `if coords.shape[1] == ndim + 1`.
-        # If that's the case, then we're missing either segment weights or the boolean indicating whether they're final,
-        #   which means they're all final coordinates. (Why? When would this happen?)
-        else:
-            # They're all final coordinates
-            isfinal = np.ones(coords.shape[0], dtype=np.bool_)
+    # This else is equivalent to `if coords.shape[1] == ndim + 1`.
+    # If that's the case, then we're missing either segment weights or the boolean indicating whether they're final,
+    #   which means they're all final coordinates. (Why? When would this happen?)
+    else:
+        # They're all final coordinates
+        isfinal = np.ones(coords.shape[0], dtype=np.bool_)
 
-        # Set coords to hold only the pcoords of the final segments
-        coords = coords[isfinal, :ndim]
-        # Weights holds the segment weights of the final segments
-        weights = allcoords[isfinal, ndim + 0]
-        # Only select out the elements of the mask corresponding to final segments
-        mask = mask[isfinal]
+    # Set coords to hold only the pcoords of the final segments
+    coords = coords[isfinal, :ndim]
+    # Weights holds the segment weights of the final segments
+    weights = allcoords[isfinal, ndim + 0]
+    # Only select out the elements of the mask corresponding to final segments
+    mask = mask[isfinal]
 
-        splitting = True
+    splitting = True
 
-        # in case where there is no final segments but initial ones in range
-        if not np.any(mask):
-            coords = allcoords[:, :ndim]
-            mask = allmask
-            weights = None
-            splitting = False
+    # in case where there is no final segments but initial ones in range
+    if not np.any(mask):
+        coords = allcoords[:, :ndim]
+        mask = allmask
+        weights = None
+        splitting = False
 
-        return coords, weights, mask, splitting, isfinal
+    return coords, weights, mask, splitting, isfinal
 
 
 def generate_mab_bins(coords, mask, output, *args, **kwargs):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -81,7 +81,7 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
 
     allcoords = np.copy(coords)
 
-    ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal = mab_parameters
+    ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist = mab_parameters
 
     coords, weights, mask, splitting, isfinal = get_final(coords, mask, ndim)
 
@@ -321,7 +321,7 @@ def generate_mab_bins(coords, mask, output, *args, **kwargs):
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
-    return ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal
+    return ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist
 
 
 class MABBinMapper(FuncBinMapper):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -24,8 +24,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
     array-like: The WE bin assignments for each segment.
     """
 
+    # TODO: Output here needs to match the size of the coordinates you're building the bins on
+    # TODO: Mask, same deal
     mab_parameters = generate_mab_bins(coords, mask, output, *args, **kwargs)
 
+    # TODO: Output here needs to match the size of the coordinates you're assigning to
+    # TODO: Mask, same deal
     assignments = assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs)
 
     return assignments
@@ -46,6 +50,11 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     -------
     array-like: The WE bin assignments for each segment.
     """
+
+    #### Things where size matters, and I can't reuse from the generate_bins:
+    # - isfinal
+    # - output
+    # - mask
 
     allcoords = np.copy(coords)
     allmask = np.copy(mask)
@@ -130,6 +139,38 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     return output
 
 
+def get_final(coords, allcoords, mask, ndim):
+    """
+    Determine which segments are "final".
+    """
+
+    if coords.shape[1] > ndim:
+
+        # If there's an extra dimension, then we've gotten the segment weights from the MAB driver.
+        if coords.shape[1] > ndim + 1:
+
+            # This last index is 1 if it's a final segment, or 0 otherwise, so cast that to a boolean.
+            isfinal = allcoords[:, ndim + 1].astype(np.bool_)
+
+        # This else is equivalent to `if coords.shape[1] == ndim + 1`.
+        # If that's the case, then we're missing either segment weights or the boolean indicating whether they're final,
+        #   which means they're all final coordinates. (Why? When would this happen?)
+        else:
+            # They're all final coordinates
+            isfinal = np.ones(coords.shape[0], dtype=np.bool_)
+
+        # Set coords to hold only the pcoords of the final segments
+        coords = coords[isfinal, :ndim]
+        # Weights holds the segment weights of the final segments
+        weights = allcoords[isfinal, ndim + 0]
+        # Only select out the elements of the mask corresponding to final segments
+        mask = mask[isfinal]
+
+        splitting = True
+
+        return coords, weights, mask, splitting, isfinal
+
+
 def generate_mab_bins(coords, mask, output, *args, **kwargs):
     """
     Binning which adaptively places bins based on the positions of extrema segments and
@@ -182,29 +223,7 @@ def generate_mab_bins(coords, mask, output, *args, **kwargs):
     # the segments should be sent in by the driver as half initial segments and half final segments
     # allcoords contains all segments
     # coords should contain ONLY final segments
-    if coords.shape[1] > ndim:
-
-        # If there's an extra dimension, then we've gotten the segment weights from the MAB driver.
-        if coords.shape[1] > ndim + 1:
-
-            # This last index is 1 if it's a final segment, or 0 otherwise, so cast that to a boolean.
-            isfinal = allcoords[:, ndim + 1].astype(np.bool_)
-
-        # This else is equivalent to `if coords.shape[1] == ndim + 1`.
-        # If that's the case, then we're missing either segment weights or the boolean indicating whether they're final,
-        #   which means they're all final coordinates. (Why? When would this happen?)
-        else:
-            # They're all final coordinates
-            isfinal = np.ones(coords.shape[0], dtype=np.bool_)
-
-        # Set coords to hold only the pcoords of the final segments
-        coords = coords[isfinal, :ndim]
-        # Weights holds the segment weights of the final segments
-        weights = allcoords[isfinal, ndim + 0]
-        # Only select out the elements of the mask corresponding to final segments
-        mask = mask[isfinal]
-
-        splitting = True
+    coords, weights, mask, splitting, isfinal = get_final(coords, allcoords, mask, ndim)
 
     # in case where there is no final segments but initial ones in range
     if not np.any(mask):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -139,10 +139,12 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     return output
 
 
-def get_final(coords, allcoords, mask, ndim):
+def get_final(coords, mask, ndim):
     """
     Determine which segments are "final".
     """
+
+    allcoords = np.copy(coords)
 
     if coords.shape[1] > ndim:
 
@@ -223,7 +225,7 @@ def generate_mab_bins(coords, mask, output, *args, **kwargs):
     # the segments should be sent in by the driver as half initial segments and half final segments
     # allcoords contains all segments
     # coords should contain ONLY final segments
-    coords, weights, mask, splitting, isfinal = get_final(coords, allcoords, mask, ndim)
+    coords, weights, mask, splitting, isfinal = get_final(coords, mask, ndim)
 
     # in case where there is no final segments but initial ones in range
     if not np.any(mask):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -3,7 +3,136 @@ from westpa.core.binning import FuncBinMapper
 
 
 def map_mab(coords, mask, output, *args, **kwargs):
-    '''Binning which adaptively places bins based on the positions of extrema segments and
+    """
+    Construct a set of WE bins according to the MAB scheme.
+
+    Adaptively places bins based on the positions of extrema segments and bottleneck segments, which are where the
+    difference in probability is the greatest along the progress coordinate.
+    Operates per dimension and places a fixed number of evenly spaced bins between the segments with the min and max
+    pcoord values. Extrema and bottleneck segments are assigned their own bins.
+
+    Parameters
+    ----------
+    coords
+    mask
+    output
+    args
+    kwargs
+
+    Returns
+    -------
+    array-like: The WE bin assignments for each segment.
+    """
+
+    mab_parameters = generate_mab_bins(coords, mask, output, *args, **kwargs)
+
+    assignments = assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs)
+
+    return assignments
+
+
+def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
+    """
+    Given a set of parameters for the MAB scheme, assign coordinates to bins.
+
+    Parameters
+    ----------
+    coords
+    mab_parameters
+    mask
+    output
+
+    Returns
+    -------
+    array-like: The WE bin assignments for each segment.
+    """
+
+    allcoords = np.copy(coords)
+    allmask = np.copy(mask)
+
+    splitting, ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal = mab_parameters
+
+    # The base number of bins is the total number of linear bins + 2 boundary bins in each dim
+    boundary_base = np.prod(nbins_per_dim)
+    bottleneck_base = boundary_base + 2 * ndim
+
+    # Iterate over segments and assign them to bins (if their mask is True)
+    for i in range(len(output)):
+
+        # If this segment isn't to be assigned, move on
+        if not allmask[i]:
+            continue
+
+        special = False
+        holder = 0
+        if splitting:
+
+            # For this segment, go through each dimension
+            for n in range(ndim):
+                coord = allcoords[i][n]
+
+                # Handle binning bottleneck segments
+                if bottleneck:
+
+                    # If this is the coordinate with the smallest relative log-weight in this dimension, then mark it,
+                    #   and store the bin
+                    if coord == difflist[n]:
+                        # Holder stores the bin index
+                        holder = bottleneck_base + 2 * n
+                        # This is True for extrema / bottlenecks
+                        special = True
+                        break
+                    elif coord == flipdifflist[n]:
+                        holder = bottleneck_base + 2 * n + 1
+                        special = True
+                        break
+
+                # Handle binning extrema
+                if coord == minlist[n]:
+                    holder = boundary_base + 2 * n
+                    special = True
+                    break
+                elif coord == maxlist[n]:
+                    holder = boundary_base + 2 * n + 1
+                    special = True
+                    break
+
+        # If this segment is neither a bottleneck or an extremum, then bin it in linear bins
+        if not special:
+
+            for n in range(ndim):
+                coord = allcoords[i][n]
+                nbins = nbins_per_dim[n]
+                minp = minlist[n]
+                maxp = maxlist[n]
+
+                # Linearly chop up the space between the minimum and maximum coordinates in this set, and assign
+                bins = np.linspace(minp, maxp, nbins + 1)
+                bin_number = np.digitize(coord, bins) - 1
+
+                # If these are all initial segments and there are no final segments
+                if isfinal is None or not isfinal[i]:
+                    # Equivalently, bin_number = np.clip(bin_number, 0, nbins-1)
+                    if bin_number >= nbins:
+                        bin_number = nbins - 1
+                    elif bin_number < 0:
+                        bin_number = 0
+
+                elif bin_number >= nbins or bin_number < 0:
+                    raise ValueError("Walker out of boundary")
+
+                # The bin-index is a scalar, so update it given the number of bins in each dimension
+                holder += bin_number * np.prod(nbins_per_dim[:n])
+
+        # Store the bin assignment
+        output[i] = holder
+
+    return output
+
+
+def generate_mab_bins(coords, mask, output, *args, **kwargs):
+    """
+    Binning which adaptively places bins based on the positions of extrema segments and
     bottleneck segments, which are where the difference in probability is the greatest
     along the progress coordinate. Operates per dimension and places a fixed number of
     evenly spaced bins between the segments with the min and max pcoord values. Extrema and
@@ -28,12 +157,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
         Whether to run PCA on the components before assignment.
 
     bottleneck: boolean, optional (default: True)
-
+        Whether to bin bottleneck segments.
 
     Returns
     -------
-    array-like: The assigned bins for each segment
-    '''
+    MAB parameters: (splitting, ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal)
+    """
 
     pca = kwargs.pop("pca", False)
     bottleneck = kwargs.pop("bottleneck", True)
@@ -173,82 +302,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
-    # The base number of bins is the total number of linear bins + 2 boundary bins in each dim
-    boundary_base = np.prod(nbins_per_dim)
-    bottleneck_base = boundary_base + 2 * ndim
-
-    # Iterate over segments and assign them to bins (if their mask is True)
-    for i in range(len(output)):
-
-        # If this segment isn't to be assigned, move on
-        if not allmask[i]:
-            continue
-
-        special = False
-        holder = 0
-        if splitting:
-
-            # For this segment, go through each dimension
-            for n in range(ndim):
-                coord = allcoords[i][n]
-
-                # Handle binning bottleneck segments
-                if bottleneck:
-
-                    # If this is the coordinate with the smallest relative log-weight in this dimension, then mark it,
-                    #   and store the bin
-                    if coord == difflist[n]:
-                        # Holder stores the bin index
-                        holder = bottleneck_base + 2 * n
-                        # This is True for extrema / bottlenecks
-                        special = True
-                        break
-                    elif coord == flipdifflist[n]:
-                        holder = bottleneck_base + 2 * n + 1
-                        special = True
-                        break
-
-                # Handle binning extrema
-                if coord == minlist[n]:
-                    holder = boundary_base + 2 * n
-                    special = True
-                    break
-                elif coord == maxlist[n]:
-                    holder = boundary_base + 2 * n + 1
-                    special = True
-                    break
-
-        # If this segment is neither a bottleneck or an extremum, then bin it in linear bins
-        if not special:
-
-            for n in range(ndim):
-                coord = allcoords[i][n]
-                nbins = nbins_per_dim[n]
-                minp = minlist[n]
-                maxp = maxlist[n]
-
-                # Linearly chop up the space between the minimum and maximum coordinates in this set, and assign
-                bins = np.linspace(minp, maxp, nbins + 1)
-                bin_number = np.digitize(coord, bins) - 1
-
-                # If these are all initial segments and there are no final segments
-                if isfinal is None or not isfinal[i]:
-                    # Equivalently, bin_number = np.clip(bin_number, 0, nbins-1)
-                    if bin_number >= nbins:
-                        bin_number = nbins - 1
-                    elif bin_number < 0:
-                        bin_number = 0
-
-                elif bin_number >= nbins or bin_number < 0:
-                    raise ValueError("Walker out of boundary")
-
-                # The bin-index is a scalar, so update it given the number of bins in each dimension
-                holder += bin_number * np.prod(nbins_per_dim[:n])
-
-        # Store the bin assignment
-        output[i] = holder
-
-    return output
+    return splitting, ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal
 
 
 class MABBinMapper(FuncBinMapper):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -4,32 +4,41 @@ from westpa.core.binning import FuncBinMapper
 
 def map_mab(coords, mask, output, *args, **kwargs):
     """
-    Construct a set of WE bins according to the MAB scheme.
-
-    Adaptively places bins based on the positions of extrema segments and bottleneck segments, which are where the
-    difference in probability is the greatest along the progress coordinate.
-    Operates per dimension and places a fixed number of evenly spaced bins between the segments with the min and max
-    pcoord values. Extrema and bottleneck segments are assigned their own bins.
+    Binning which adaptively places bins based on the positions of extrema segments and
+    bottleneck segments, which are where the difference in probability is the greatest
+    along the progress coordinate. Operates per dimension and places a fixed number of
+    evenly spaced bins between the segments with the min and max pcoord values. Extrema and
+    bottleneck segments are assigned their own bins.
 
     Parameters
     ----------
-    coords
-    mask
-    output
-    args
-    kwargs
+    coords: array-like
+        Set of coordinates to map to WE bins. Shape is (n_segments, n_dimensions + 1), where the extra dimension is
+        a boolean indicating whether it's a final segment or not.
+
+    mask: array-like
+        A mask indicating which coordinates to assign bins to.
+
+    output: array-like
+        Array to populate with the mapped WE bins.
+
+    nbins_per_dim: array-like
+        Array storing the number of WE bins to place in each dimension.
+
+    pca: boolean, optional (default: False)
+        Whether to run PCA on the components before assignment.
+
+    bottleneck: boolean, optional (default: True)
+        Whether to bin bottleneck segments.
 
     Returns
     -------
     array-like: The WE bin assignments for each segment.
     """
 
-    # TODO: Output here needs to match the size of the coordinates you're building the bins on
-    # TODO: Mask, same deal
     mab_parameters = generate_mab_bins(coords, mask, output, *args, **kwargs)
 
-    # TODO: Output here needs to match the size of the coordinates you're assigning to
-    # TODO: Mask, same deal
+    # coords, mask, output may be a different size here
     assignments = assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs)
 
     return assignments
@@ -51,15 +60,14 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     array-like: The WE bin assignments for each segment.
     """
 
-    #### Things where size matters, and I can't reuse from the generate_bins:
-    # - isfinal
-    # - output
-    # - mask
+    # isfinal, output, and mask cannot be copied over through the parameters, as you may want to use one set of data
+    #   to generate the MAB parameters, and then apply that to another set of data.
 
     allcoords = np.copy(coords)
-    allmask = np.copy(mask)
 
-    splitting, ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal = mab_parameters
+    ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal = mab_parameters
+
+    coords, weights, mask, splitting, isfinal = get_final(coords, mask, ndim)
 
     # The base number of bins is the total number of linear bins + 2 boundary bins in each dim
     boundary_base = np.prod(nbins_per_dim)
@@ -69,7 +77,7 @@ def assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs):
     for i in range(len(output)):
 
         # If this segment isn't to be assigned, move on
-        if not allmask[i]:
+        if not mask[i]:
             continue
 
         special = False
@@ -145,6 +153,7 @@ def get_final(coords, mask, ndim):
     """
 
     allcoords = np.copy(coords)
+    allmask = np.copy(mask)
 
     if coords.shape[1] > ndim:
 
@@ -170,37 +179,24 @@ def get_final(coords, mask, ndim):
 
         splitting = True
 
+        # in case where there is no final segments but initial ones in range
+        if not np.any(mask):
+            coords = allcoords[:, :ndim]
+            mask = allmask
+            weights = None
+            splitting = False
+
         return coords, weights, mask, splitting, isfinal
 
 
 def generate_mab_bins(coords, mask, output, *args, **kwargs):
     """
-    Binning which adaptively places bins based on the positions of extrema segments and
-    bottleneck segments, which are where the difference in probability is the greatest
-    along the progress coordinate. Operates per dimension and places a fixed number of
-    evenly spaced bins between the segments with the min and max pcoord values. Extrema and
-    bottleneck segments are assigned their own bins.
+    Construct a set of WE bins according to the MAB scheme.
 
-    Parameters
-    ----------
-    coords: array-like
-        Set of coordinates to map to WE bins. Shape is (n_segments, n_dimensions + 1), where the extra dimension is
-        a boolean indicating whether it's a final segment or not.
-
-    mask: array-like
-        A mask indicating which coordinates to assign bins to.
-
-    output: array-like
-        Array to populate with the mapped WE bins.
-
-    nbins_per_dim: array-like
-        Array storing the number of WE bins to place in each dimension.
-
-    pca: boolean, optional (default: False)
-        Whether to run PCA on the components before assignment.
-
-    bottleneck: boolean, optional (default: True)
-        Whether to bin bottleneck segments.
+    Adaptively places bins based on the positions of extrema segments and bottleneck segments, which are where the
+    difference in probability is the greatest along the progress coordinate.
+    Operates per dimension and places a fixed number of evenly spaced bins between the segments with the min and max
+    pcoord values. Extrema and bottleneck segments are assigned their own bins.
 
     Returns
     -------
@@ -215,24 +211,10 @@ def generate_mab_bins(coords, mask, output, *args, **kwargs):
     if not np.any(mask):
         return output
 
-    allcoords = np.copy(coords)
-    allmask = np.copy(mask)
-
-    weights = None
-    isfinal = None
-    splitting = False
-
     # the segments should be sent in by the driver as half initial segments and half final segments
     # allcoords contains all segments
     # coords should contain ONLY final segments
     coords, weights, mask, splitting, isfinal = get_final(coords, mask, ndim)
-
-    # in case where there is no final segments but initial ones in range
-    if not np.any(mask):
-        coords = allcoords[:, :ndim]
-        mask = allmask
-        weights = None
-        splitting = False
 
     # If PCA is enabled, then do PCA on the coordinates before assignment
     varcoords = np.copy(coords)
@@ -323,7 +305,7 @@ def generate_mab_bins(coords, mask, output, *args, **kwargs):
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
-    return splitting, ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal
+    return ndim, bottleneck, nbins_per_dim, difflist, flipdifflist, minlist, maxlist, isfinal
 
 
 class MABBinMapper(FuncBinMapper):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -1,8 +1,9 @@
 import numpy as np
 from westpa.core.binning import FuncBinMapper
+from westpa.core.binning.assign import index_dtype
 
 
-def map_mab(coords, mask, output, *args, **kwargs):
+def map_mab(coords, mask, output, assign_coords=None, *args, **kwargs):
     """
     Binning which adaptively places bins based on the positions of extrema segments and
     bottleneck segments, which are where the difference in probability is the greatest
@@ -22,6 +23,9 @@ def map_mab(coords, mask, output, *args, **kwargs):
     output: array-like
         Array to populate with the mapped WE bins.
 
+    assign_coords: array-like, optional (default: None)
+        An optional set of coordinates to assign, based on MAB parameters calculated from :code:`coords`.
+
     nbins_per_dim: array-like
         Array storing the number of WE bins to place in each dimension.
 
@@ -36,10 +40,22 @@ def map_mab(coords, mask, output, *args, **kwargs):
     array-like: The WE bin assignments for each segment.
     """
 
+    # If you provided a different set of coordinates to assign, then build a new mask based on that.
+    if assign_coords is not None:
+        assign_mask = np.ones((len(assign_coords),), dtype=np.bool_)
+        assign_output = np.empty((len(assign_coords),), dtype=index_dtype)
+
+    # If assign_coords is not provided, then this should default to the original behavior and just assign the segments
+    #   that were initially provided
+    else:
+        assign_coords = coords
+        assign_mask = mask
+        assign_output = output
+
     mab_parameters = generate_mab_bins(coords, mask, output, *args, **kwargs)
 
     # coords, mask, output may be a different size here
-    assignments = assign_to_mab_bins(coords, mab_parameters, mask, output, *args, **kwargs)
+    assignments = assign_to_mab_bins(assign_coords, mab_parameters, assign_mask, assign_output, *args, **kwargs)
 
     return assignments
 

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -3,7 +3,7 @@ from westpa.core.binning import FuncBinMapper
 from westpa.core.binning.assign import index_dtype
 
 
-def map_mab(coords, mask, output, assign_coords=None, *args, **kwargs):
+def map_mab(coords, mask, output, *args, assign_coords=None, **kwargs):
     """
     Binning which adaptively places bins based on the positions of extrema segments and
     bottleneck segments, which are where the difference in probability is the greatest

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -353,4 +353,8 @@ class MABBinMapper(FuncBinMapper):
         kwargs = dict(nbins_per_dim=nbins, bottleneck=bottleneck, pca=pca)
         ndim = len(nbins)
         n_total_bins = np.prod(nbins) + ndim * (2 + 2 * bottleneck)
+
+        self.nbins_per_dim = nbins
+        self.ndim = ndim
+
         super().__init__(map_mab, n_total_bins, kwargs=kwargs)

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -7,7 +7,33 @@ def map_mab(coords, mask, output, *args, **kwargs):
     bottleneck segments, which are where the difference in probability is the greatest
     along the progress coordinate. Operates per dimension and places a fixed number of
     evenly spaced bins between the segments with the min and max pcoord values. Extrema and
-    bottleneck segments are assigned their own bins.'''
+    bottleneck segments are assigned their own bins.
+
+    Parameters
+    ----------
+    coords: array-like
+        Set of coordinates to map to WE bins. Shape is (n_segments, n_dimensions + 1), where the extra dimension is
+        a boolean indicating whether it's a final segment or not.
+
+    mask: array-like
+        A mask indicating which coordinates to assign bins to.
+
+    output: array-like
+        Array to populate with the mapped WE bins.
+
+    nbins_per_dim: array-like
+        Array storing the number of WE bins to place in each dimension.
+
+    pca: boolean, optional (default: False)
+        Whether to run PCA on the components before assignment.
+
+    bottleneck: boolean, optional (default: True)
+
+
+    Returns
+    -------
+    array-like: The assigned bins for each segment
+    '''
 
     pca = kwargs.pop("pca", False)
     bottleneck = kwargs.pop("bottleneck", True)
@@ -28,13 +54,27 @@ def map_mab(coords, mask, output, *args, **kwargs):
     # allcoords contains all segments
     # coords should contain ONLY final segments
     if coords.shape[1] > ndim:
+
+        # If there's an extra dimension, then we've gotten the segment weights from the MAB driver.
         if coords.shape[1] > ndim + 1:
+
+            # This last index is 1 if it's a final segment, or 0 otherwise, so cast that to a boolean.
             isfinal = allcoords[:, ndim + 1].astype(np.bool_)
+
+        # This else is equivalent to `if coords.shape[1] == ndim + 1`.
+        # If that's the case, then we're missing either segment weights or the boolean indicating whether they're final,
+        #   which means they're all final coordinates. (Why? When would this happen?)
         else:
+            # They're all final coordinates
             isfinal = np.ones(coords.shape[0], dtype=np.bool_)
+
+        # Set coords to hold only the pcoords of the final segments
         coords = coords[isfinal, :ndim]
+        # Weights holds the segment weights of the final segments
         weights = allcoords[isfinal, ndim + 0]
+        # Only select out the elements of the mask corresponding to final segments
         mask = mask[isfinal]
+
         splitting = True
 
     # in case where there is no final segments but initial ones in range
@@ -44,6 +84,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
         weights = None
         splitting = False
 
+    # If PCA is enabled, then do PCA on the coordinates before assignment
     varcoords = np.copy(coords)
     originalcoords = np.copy(coords)
     if pca and len(output) > 1:
@@ -63,6 +104,9 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
     maxlist = []
     minlist = []
+
+    # List of the difference of the logs of each segment's weight to the log of all the weight to the right of it,
+    #   or (for flipdifflist) to the left of it
     difflist = []
     flipdifflist = []
     for n in range(ndim):
@@ -73,59 +117,98 @@ def map_mab(coords, mask, output, *args, **kwargs):
         minlist.append(mincoord)
 
         # detect the bottleneck segments, this uses the weights
+        # Splitting is False if there are no final segments provided, only initial segments
         if splitting:
+            # Make temp an array of [[segment 0 pcoord, segment 0 weight], ...]
+            # Remember that this is just a pcoord in a single dimension, we're looping over dimensions
             temp = np.column_stack((originalcoords[mask, n], weights[mask]))
             sorted_indices = temp[:, 0].argsort()
+
             temp = temp[sorted_indices]
+
+            # Set 0 weights to a very small number -- necessary because we're taking logs later.
+            # This is equivalently temp[ temp[:,1] == 0 ] = 1e-39
             for p in range(len(temp)):
                 if temp[p][1] == 0:
                     temp[p][1] = 10 ** -39
+
             fliptemp = np.flipud(temp)
 
+            # Equivalent to initializing these lists as [None for _ in range(ndim)]
             difflist.append(None)
             flipdifflist.append(None)
+
+            # These aren't actually used
             maxdiff = 0
             flipmaxdiff = 0
+
+            # Loop over segments to find the largest
             for i in range(1, len(temp) - 1):
                 comprob = 0
                 flipcomprob = 0
                 j = i + 1
+
+                # Get the total weight to the left and right of this segment, not including the segment
+                # I think this loop is equivalently
+                #   comprob = sum(temp[i+1:, 1])
+                #   flipcomprob = sum(temp[:i])
                 while j < len(temp):
                     comprob = comprob + temp[j][1]
                     flipcomprob = flipcomprob + fliptemp[j][1]
                     j = j + 1
+
+                # Compute log(total weight to the right / segment weight)
+                # Store the coordinates of the segment with the highest ratio of this in this dimension,
+                #   i.e. the smallest weight relative to the total weight
+                # We do this for both "directions" (i.e. with the fliplist as well) so that we can catch bottlenecks
+                #   on both the leading and trailing edge.
                 diff = -np.log(comprob) + np.log(temp[i][1])
                 if diff > maxdiff:
                     difflist[n] = temp[i][0]
                     maxdiff = diff
+
+                # Compute log(total weight to the left / segment weight)
                 flipdiff = -np.log(flipcomprob) + np.log(fliptemp[i][1])
                 if flipdiff > flipmaxdiff:
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
-    # assign segments to bins
-    # the total number of linear bins + 2 boundary bins each dim
+    # The base number of bins is the total number of linear bins + 2 boundary bins in each dim
     boundary_base = np.prod(nbins_per_dim)
     bottleneck_base = boundary_base + 2 * ndim
+
+    # Iterate over segments and assign them to bins (if their mask is True)
     for i in range(len(output)):
+
+        # If this segment isn't to be assigned, move on
         if not allmask[i]:
             continue
 
         special = False
         holder = 0
         if splitting:
+
+            # For this segment, go through each dimension
             for n in range(ndim):
                 coord = allcoords[i][n]
 
+                # Handle binning bottleneck segments
                 if bottleneck:
+
+                    # If this is the coordinate with the smallest relative log-weight in this dimension, then mark it,
+                    #   and store the bin
                     if coord == difflist[n]:
+                        # Holder stores the bin index
                         holder = bottleneck_base + 2 * n
+                        # This is True for extrema / bottlenecks
                         special = True
                         break
                     elif coord == flipdifflist[n]:
                         holder = bottleneck_base + 2 * n + 1
                         special = True
                         break
+
+                # Handle binning extrema
                 if coord == minlist[n]:
                     holder = boundary_base + 2 * n
                     special = True
@@ -135,35 +218,45 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     special = True
                     break
 
+        # If this segment is neither a bottleneck or an extremum, then bin it in linear bins
         if not special:
+
             for n in range(ndim):
                 coord = allcoords[i][n]
                 nbins = nbins_per_dim[n]
                 minp = minlist[n]
                 maxp = maxlist[n]
 
+                # Linearly chop up the space between the minimum and maximum coordinates in this set, and assign
                 bins = np.linspace(minp, maxp, nbins + 1)
                 bin_number = np.digitize(coord, bins) - 1
 
+                # If these are all initial segments and there are no final segments
                 if isfinal is None or not isfinal[i]:
+                    # Equivalently, bin_number = np.clip(bin_number, 0, nbins-1)
                     if bin_number >= nbins:
                         bin_number = nbins - 1
                     elif bin_number < 0:
                         bin_number = 0
+
                 elif bin_number >= nbins or bin_number < 0:
                     raise ValueError("Walker out of boundary")
 
+                # The bin-index is a scalar, so update it given the number of bins in each dimension
                 holder += bin_number * np.prod(nbins_per_dim[:n])
 
+        # Store the bin assignment
         output[i] = holder
 
     return output
 
 
 class MABBinMapper(FuncBinMapper):
-    '''Adaptively place bins in between minimum and maximum segments along
+    """
+    Adaptively place bins in between minimum and maximum segments along
     the progress coordinte. Extrema and bottleneck segments are assigned
-    to their own bins.'''
+    to their own bins.
+    """
 
     def __init__(self, nbins, bottleneck=True, pca=False):
         kwargs = dict(nbins_per_dim=nbins, bottleneck=bottleneck, pca=pca)

--- a/src/westpa/core/binning/mab_driver.py
+++ b/src/westpa/core/binning/mab_driver.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 
 class MABDriver(WEDriver):
-    def assign(self, segments, initializing=False, **kwargs):
+    def assign(self, segments, initializing=False):
         '''
         Assign segments to initial and final bins, and update the (internal) lists of used and available
         initial states.
@@ -27,7 +27,7 @@ class MABDriver(WEDriver):
             all_pcoords[n_segments + iseg] = np.append(segment.pcoord[-1, :], [segment.weight, 1.0])
 
         # assign based on initial and final progress coordinates
-        assignments = self.bin_mapper.assign(all_pcoords, **kwargs)
+        assignments = self.bin_mapper.assign(all_pcoords)
         initial_assignments = assignments[:n_segments]
         if initializing:
             final_assignments = initial_assignments

--- a/src/westpa/core/binning/mab_driver.py
+++ b/src/westpa/core/binning/mab_driver.py
@@ -7,21 +7,27 @@ log = logging.getLogger(__name__)
 
 
 class MABDriver(WEDriver):
-    def assign(self, segments, initializing=False):
-        '''Assign segments to initial and final bins, and update the (internal) lists of used and available
-        initial states. This function is adapted to the MAB scheme, so that the inital and final segments are
-        sent to the bin mapper at the same time, otherwise the inital and final bin boundaries can be inconsistent.'''
+    def assign(self, segments, initializing=False, **kwargs):
+        '''
+        Assign segments to initial and final bins, and update the (internal) lists of used and available
+        initial states.
+
+        This function is adapted to the MAB scheme, so that the inital and final segments are
+        sent to the bin mapper at the same time, otherwise the inital and final bin boundaries can be inconsistent.
+        '''
 
         # collect initial and final coordinates into one place
         n_segments = len(segments)
         all_pcoords = np.empty((n_segments * 2, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
 
+        # Here, we build the array of all_pcoords, which is a list of initial pcoords, followed by final pcoords.
+        # Go through each segment, and set each element of all_pcoords as [*segment pcoords, weight, boolean is final]
         for iseg, segment in enumerate(segments):
             all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 0.0])
             all_pcoords[n_segments + iseg] = np.append(segment.pcoord[-1, :], [segment.weight, 1.0])
 
         # assign based on initial and final progress coordinates
-        assignments = self.bin_mapper.assign(all_pcoords)
+        assignments = self.bin_mapper.assign(all_pcoords, **kwargs)
         initial_assignments = assignments[:n_segments]
         if initializing:
             final_assignments = initial_assignments


### PR DESCRIPTION
This was a set of changes aimed to split out the functionality of the MAB bin_mapper to allow building a set of MAB bins based on one iteration, and apply it to another. In other words, this decouples the logic for determining the MAB bins from the logic for assigning them.

I originally wrote this so that it would be possible to consistently use one set of bin definitions and apply them to a range of iterations. I.e., "using the MAB scheme, obtain bin definitions using the walkers at iteration XX, and then bin walkers in iterations AA-BB based on that".

I think for my own use-case, I'll actually end up doing something slightly different, at least in the short term. However, maybe you'd still like to keep some of these changes around. 

b902595 is helpful (and I'll need that at least), and 2ff361e was just me writing a bunch of comments as I figured out how things worked, so maybe that would also be helpful to keep.

Any existing usage of MAB **should not be affected by this** -- these changes should be fully backwards-compatible and non-breaking.