### PR TITLE
WESTPA2-threshold2 fix

### DIFF
--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -197,6 +197,11 @@ class WESimManager:
         self.rc.pstatus('norm = {:g}, error in norm = {:g} ({:.2g}*epsilon)'.format(norm, (norm - 1), (norm - 1) / EPS))
         self.rc.pflush()
 
+        if min_seg_prob < 1e-100:
+            log.warning(
+                '\n Minimum segment weight is < 1e-100 and might not be physically relevant. Please reconsider your progress coordinate or binning scheme.'
+            )
+
         if save_summary:
             iter_summary = self.data_manager.get_iter_summary()
             iter_summary['n_particles'] = len(segments)

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -534,10 +534,10 @@ class WEDriver:
             #   print(i.weight)
             # print(self.smallest_allowed_weight)
             if all(new_segment.weight < self.smallest_allowed_weight for new_segment in new_segments_list):
-                #    print("instance of threshold break (bw)")
+                #print("instance of threshold break (bw)")
                 bin.add(segment)
             else:
-                #    print("no threshold break (bw)")
+                #print("no threshold break (bw)")
                 bin.update(new_segments_list)
 
     # KFW CHECK BACK            for new_segment in new_segments_list:
@@ -560,10 +560,10 @@ class WEDriver:
             bin.difference_update(to_merge)
             new_segment, parent = self._merge_walkers(to_merge, cumul_weight, bin)
             if new_segment.weight > self.largest_allowed_weight:
-                # print("instance of threshold break (bw)")
+                #print("instance of threshold break (bw)")
                 bin.add(to_merge)
             else:
-                # print("no threshold break (bw)")
+                #print("no threshold break (bw)")
                 bin.add(new_segment)
 
     # KFW CHECK BACK            try:
@@ -585,7 +585,9 @@ class WEDriver:
         threshold_target_count = target_count
 
         # split
+        split_counter = 0
         while len(bin) < threshold_target_count:
+            split_counter += 1
             for i in sorted_groups:
                 log.debug('adjusting counts by splitting')
                 # always split the highest probability walker into two
@@ -594,15 +596,15 @@ class WEDriver:
                 bin.remove(segments[-1])
                 i.remove(segments[-1])
                 new_segments_list = self._split_walker(segments[-1], 2, bin)
-                # for j in new_segments_list:
-                #   print(j.weight)
-                # print(self.smallest_allowed_weight)
+                #print(new_segments_list)
+                #for j in new_segments_list:
+                #    print(j.weight)
                 if all(new_segment.weight < self.smallest_allowed_weight for new_segment in new_segments_list):
-                    #    print("instance of threshold break (ac)")
+                    #print("instance of threshold break (ac)")
                     bin.add(segments[-1])
                     i.add(segments[-1])
                 else:
-                    #    print("no threshold break (ac)")
+                    #print("no threshold break (ac)")
                     i.update(new_segments_list)
                     bin.update(new_segments_list)
 
@@ -614,13 +616,16 @@ class WEDriver:
 
                 if len(bin) == target_count:
                     break
-                elif i == sorted_groups[-1]:
+                elif i == sorted_groups[-1] and split_counter == target_count:
                     threshold_target_count = len(bin)
 
+        print(split_counter)
         threshold_target_count = target_count
 
         # merge
+        merge_counter = 0
         while len(bin) > threshold_target_count:
+            merge_counter += 1
             sorted_groups.reverse()
             # Adjust to go from lowest weight group to highest to merge
             for i in sorted_groups:
@@ -649,8 +654,9 @@ class WEDriver:
                     # in bash, "find . -name \*.py | xargs fgrep -n '_merge_walkers'"
                     if len(bin) == target_count:
                         break
-                    elif i == sorted_groups[-1]:
+                    elif i == sorted_groups[-1] and merge_counter == target_count:
                         threshold_target_count = len(bin)
+            print(merge_counter)
 
     def _check_pre(self):
         for ibin, _bin in enumerate(self.next_iter_binning):

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -937,8 +937,3 @@ class WEDriver:
                 max_weight=weights[-1],
             )
             log.log(level, log_msg)
-
-            if weights[0] < 1e-100:
-                log.warning(
-                    '\n Min weight is < 1e-100 and might not be physically relevant. Please reconsider your progress coordinate or binning scheme.'
-                )

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -937,3 +937,8 @@ class WEDriver:
                 max_weight=weights[-1],
             )
             log.log(level, log_msg)
+
+            if weights[0] < 1e-100:
+                log.warning(
+                    '\n Min weight is < 1e-100 and might not be physically relevant. Please reconsider your progress coordinate or binning scheme.'
+                )

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -2,7 +2,6 @@ import logging
 import math
 import operator
 import random
-from copy import deepcopy
 
 import numpy as np
 
@@ -587,7 +586,7 @@ class WEDriver:
 
         # split
         while len(bin) < threshold_target_count:
-            last_bin = deepcopy(bin)
+            last_bin = len(bin)
             for i in sorted_groups:
                 log.debug('adjusting counts by splitting')
                 # always split the highest probability walker into two
@@ -616,14 +615,16 @@ class WEDriver:
 
                 if len(bin) == target_count:
                     break
-                elif i == sorted_groups[-1] and last_bin == bin:  # If the last "for" iteration didn't change anything, soft-break.
+                elif i == sorted_groups[-1] and last_bin == len(
+                    bin
+                ):  # If the last "for" iteration didn't change anything, soft-break.
                     threshold_target_count = len(bin)
 
         threshold_target_count = target_count
 
         # merge
         while len(bin) > threshold_target_count:
-            last_bin = deepcopy(bin)
+            last_bin = len(bin)
             sorted_groups.reverse()
             # Adjust to go from lowest weight group to highest to merge
             for i in sorted_groups:
@@ -652,8 +653,8 @@ class WEDriver:
                     # in bash, "find . -name \*.py | xargs fgrep -n '_merge_walkers'"
                     if len(bin) == target_count:
                         break
-                    elif (
-                        i == sorted_groups[-1] and last_bin == bin
+                    elif i == sorted_groups[-1] and last_bin == len(
+                        bin
                     ):  # If the last "for" iteration didn't change anything, soft-break.
                         threshold_target_count = len(bin)
 

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -619,7 +619,6 @@ class WEDriver:
                 elif i == sorted_groups[-1] and split_counter == target_count:
                     threshold_target_count = len(bin)
 
-        print(split_counter)
         threshold_target_count = target_count
 
         # merge
@@ -656,7 +655,6 @@ class WEDriver:
                         break
                     elif i == sorted_groups[-1] and merge_counter == target_count:
                         threshold_target_count = len(bin)
-            print(merge_counter)
 
     def _check_pre(self):
         for ibin, _bin in enumerate(self.next_iter_binning):

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -2,6 +2,7 @@ import logging
 import math
 import operator
 import random
+from copy import deepcopy
 
 import numpy as np
 
@@ -585,9 +586,8 @@ class WEDriver:
         threshold_target_count = target_count
 
         # split
-        split_counter = 0
         while len(bin) < threshold_target_count:
-            split_counter += 1
+            last_bin = deepcopy(bin)
             for i in sorted_groups:
                 log.debug('adjusting counts by splitting')
                 # always split the highest probability walker into two
@@ -616,15 +616,14 @@ class WEDriver:
 
                 if len(bin) == target_count:
                     break
-                elif i == sorted_groups[-1] and split_counter == target_count:
+                elif i == sorted_groups[-1] and last_bin == bin:  # If the last "for" iteration didn't change anything, soft-break.
                     threshold_target_count = len(bin)
 
         threshold_target_count = target_count
 
         # merge
-        merge_counter = 0
         while len(bin) > threshold_target_count:
-            merge_counter += 1
+            last_bin = deepcopy(bin)
             sorted_groups.reverse()
             # Adjust to go from lowest weight group to highest to merge
             for i in sorted_groups:
@@ -653,7 +652,9 @@ class WEDriver:
                     # in bash, "find . -name \*.py | xargs fgrep -n '_merge_walkers'"
                     if len(bin) == target_count:
                         break
-                    elif i == sorted_groups[-1] and merge_counter == target_count:
+                    elif (
+                        i == sorted_groups[-1] and last_bin == bin
+                    ):  # If the last "for" iteration didn't change anything, soft-break.
                         threshold_target_count = len(bin)
 
     def _check_pre(self):

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -534,10 +534,10 @@ class WEDriver:
             #   print(i.weight)
             # print(self.smallest_allowed_weight)
             if all(new_segment.weight < self.smallest_allowed_weight for new_segment in new_segments_list):
-                #print("instance of threshold break (bw)")
+                # print("instance of threshold break (bw)")
                 bin.add(segment)
             else:
-                #print("no threshold break (bw)")
+                # print("no threshold break (bw)")
                 bin.update(new_segments_list)
 
     # KFW CHECK BACK            for new_segment in new_segments_list:
@@ -560,10 +560,10 @@ class WEDriver:
             bin.difference_update(to_merge)
             new_segment, parent = self._merge_walkers(to_merge, cumul_weight, bin)
             if new_segment.weight > self.largest_allowed_weight:
-                #print("instance of threshold break (bw)")
+                # print("instance of threshold break (bw)")
                 bin.add(to_merge)
             else:
-                #print("no threshold break (bw)")
+                # print("no threshold break (bw)")
                 bin.add(new_segment)
 
     # KFW CHECK BACK            try:
@@ -596,15 +596,15 @@ class WEDriver:
                 bin.remove(segments[-1])
                 i.remove(segments[-1])
                 new_segments_list = self._split_walker(segments[-1], 2, bin)
-                #print(new_segments_list)
-                #for j in new_segments_list:
+                # print(new_segments_list)
+                # for j in new_segments_list:
                 #    print(j.weight)
                 if all(new_segment.weight < self.smallest_allowed_weight for new_segment in new_segments_list):
-                    #print("instance of threshold break (ac)")
+                    # print("instance of threshold break (ac)")
                     bin.add(segments[-1])
                     i.add(segments[-1])
                 else:
-                    #print("no threshold break (ac)")
+                    # print("no threshold break (ac)")
                     i.update(new_segments_list)
                     bin.update(new_segments_list)
 


### PR DESCRIPTION
TL:DR - Made changes. Not heavily tested at all so don't merge it right off the bat. Also added a warning if min_weight < 1e-100.

Just documenting my changes/rational:
I added in an extra condition to each of the `while` loops in `adjust_counts` so they can run a number of times until the "bin" object is unchanges (ie. list of segments from the previous for loop == the next one). This is to prevent the code from exiting prematurely just because the `for` loop ran once (i.e. the `elif` statement conditions were initially too broad). This change should not affect the threshold usage at all and now allows the driver to reproduce intended behavior from the original code. 

The `test_recycle` test in `test_we_driver.py` actually requires the split `for` loop in `adjust_counts` to execute twice in order to get the final 4 segments. The changes in this branch only allow the for loop to run exactly once (and thus breaking out of the `while` loop even when a threshold is not explicitly specified), so the test fails. Actually glad the CI caught it.

